### PR TITLE
Default implementation of kolodaSpeedThatCardShouldDrag

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -36,6 +36,10 @@ public extension KolodaViewDataSource {
         return nil
     }
     
+    func kolodaSpeedThatCardShouldDrag(_ koloda: KolodaView) -> DragSpeed {
+		return .default
+	}
+    
 }
 
 public protocol KolodaViewDelegate: class {


### PR DESCRIPTION
This removes the necessity for all datasources to implement `kolodaSpeedThatCardShouldDrag` when the default speed is sufficient.